### PR TITLE
SW-20: Mismatch Between Mobile App Label and Profile Comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ To install it from there run
 ```typescript
 npm install "git@github.com:MeticulousHome/meticulous-typescript-profile.git#dist"
 ```
+
+## Exit trigger comparisons
+
+Numeric exit triggers support four comparison operators: greater than (`>`),
+less than (`<`), greater than or equal to (`>=`), and less than or equal to
+(`<=`). Each explicit operator keeps its own strict or inclusive boundary
+semantics. When `comparison` is omitted, consumers retain the existing
+greater-than-or-equal (`>=`) behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meticulous-home/espresso-profile",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meticulous-home/espresso-profile",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "GPL-3.0",
       "devDependencies": {
         "prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@meticulous-home/espresso-profile",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Typescript definitions to deal with the meticulous profiles",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --project tsconfig.type-tests.json",
     "format": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts}\" --write",
     "format:check": "prettier --config .prettierrc \"{src/**/,.github/**/,}*.{tsx,ts}\" --check"
   },

--- a/src/ExitTriggers.ts
+++ b/src/ExitTriggers.ts
@@ -1,6 +1,6 @@
 import { VariableOrValue } from '.';
 
-export type ExitTriggerComparison = '>=' | '<=';
+export type ExitTriggerComparison = '>' | '<' | '>=' | '<=';
 
 export const ExitTriggerRelativeAllowed: Record<ExitTriggerType, boolean> = {
   pressure: false,
@@ -35,5 +35,6 @@ export interface ExitTrigger {
   type: ExitTriggerType;
   value: VariableOrValue;
   relative?: boolean;
-  comparison?: ExitTriggerComparison; // ">=" is assumed if non existant
+  /** Defaults to greater-than-or-equal (`>=`) when omitted. */
+  comparison?: ExitTriggerComparison;
 }

--- a/tsconfig.type-tests.json
+++ b/tsconfig.type-tests.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "type-tests/**/*"]
+}

--- a/type-tests/ExitTriggers.test-d.ts
+++ b/type-tests/ExitTriggers.test-d.ts
@@ -1,0 +1,50 @@
+import type {
+  ExitTrigger,
+  ExitTriggerComparison,
+  ExitTriggerType
+} from '../src';
+
+const greaterThan: ExitTriggerComparison = '>';
+const lessThan: ExitTriggerComparison = '<';
+const greaterThanOrEqual: ExitTriggerComparison = '>=';
+const lessThanOrEqual: ExitTriggerComparison = '<=';
+
+const numericTriggerTypes = [
+  'weight',
+  'time',
+  'pressure',
+  'flow',
+  'piston_position',
+  'power'
+] as const satisfies readonly ExitTriggerType[];
+
+const comparisons = [
+  greaterThan,
+  lessThan,
+  greaterThanOrEqual,
+  lessThanOrEqual
+] as const;
+
+const numericTriggers = numericTriggerTypes.reduce<ExitTrigger[]>(
+  (triggers, type) => [
+    ...triggers,
+    ...comparisons.map((comparison) => ({ type, value: 0, comparison }))
+  ],
+  []
+);
+
+const omittedComparison: ExitTrigger = {
+  type: 'weight',
+  value: 0
+};
+
+// @ts-expect-error Equality is not a supported exit-trigger comparison.
+const unsupportedEquality: ExitTriggerComparison = '==';
+
+// @ts-expect-error Inequality is not a supported exit-trigger comparison.
+const unsupportedInequality: ExitTriggerComparison = '!=';
+
+void numericTriggers;
+void omittedComparison;
+void unsupportedEquality;
+void unsupportedInequality;


### PR DESCRIPTION
Expanded the profile contract to all four comparators, preserved the omitted `>=` fallback, added compile-time coverage for all six numeric trigger types, documented semantics, and bumped the package to 0.4.3. No normalization or migration was introduced.

Linear: https://linear.app/meticulous-home/issue/SW-20/mismatch-between-mobile-app-label-and-profile-comparator

> Draft created by the local agent orchestrator. Human approval and merge are required.